### PR TITLE
Releases/v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,142 +1,228 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "2.1.0",
-  "lockfileVersion": 1,
+  "version": "3.0.0-alpha.1",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "anymatch": {
+  "packages": {
+    "": {
+      "name": "@jbrowneuk/style-bundle",
+      "version": "3.0.0-alpha.1",
+      "license": "MIT",
+      "devDependencies": {
+        "sass": "^1.70.0"
+      }
+    },
+    "node_modules/anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "binary-extensions": {
+    "node_modules/binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "braces": {
+    "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "chokidar": {
+    "node_modules/chokidar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
       "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.4.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.2"
       }
     },
-    "fill-range": {
+    "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "fsevents": {
+    "node_modules/fsevents": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
       "dev": true,
-      "optional": true
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
-    "glob-parent": {
+    "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "is-binary-path": {
+    "node_modules/immutable": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "is-extglob": {
+    "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "is-glob": {
+    "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "is-number": {
+    "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
-    "normalize-path": {
+    "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "picomatch": {
+    "node_modules/picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
-    "readdirp": {
+    "node_modules/readdirp": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
-    "sass": {
-      "version": "1.26.10",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.10.tgz",
-      "integrity": "sha512-bzN0uvmzfsTvjz0qwccN1sPm2HxxpNI/Xa+7PlUEMS+nQvbyuEK7Y0qFqxlPHhiNHb1Ze8WQJtU31olMObkAMw==",
+    "node_modules/sass": {
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
+      "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
       "dev": true,
-      "requires": {
-        "chokidar": ">=2.0.0 <4.0.0"
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "to-regex-range": {
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jbrowneuk/style-bundle",
-      "version": "3.0.0-alpha.1",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "sass": "^1.70.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "2.1.0",
+  "version": "3.0.0-alpha.1",
   "description": "Global style files for Jason B’s Portfolio",
   "main": "palette.css",
   "files": [
@@ -10,7 +10,7 @@
   "author": "Jason B <jason@browne.me.uk>",
   "license": "MIT",
   "devDependencies": {
-    "sass": "^1.26.10"
+    "sass": "^1.70.0"
   },
   "scripts": {
     "generate": "node src/generate.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "description": "Global style files for Jason B’s Portfolio",
   "main": "palette.css",
   "files": [

--- a/palette.css
+++ b/palette.css
@@ -40,196 +40,106 @@
   --_color-shadow: rgba(0, 0, 0, 0.25);
   --_color-overlay: rgba(241, 245, 248, 0.8);
 
-  --color-default-background: var(--_color-neutral-2);
-  --color-default-foreground: var(--_color-neutral-7);
-  --color-default-border: var(--_color-neutral-3);
-  --color-default-shadow: var(--_color-shadow);
+  /* Globals */
+  --generic_color_shadow: var(--_color-shadow);
 
-  --color-light-foreground: var(--_color-neutral-1);
-  --color-light-border: var(--_color-neutral-2);
+  --error_color: var(--_color-primary-red-1);
 
-  --color-default-gradient: var(--_color-primary-blue-3)
-    linear-gradient(
-      to bottom,
-      var(--_color-primary-blue-2),
-      var(--_color-primary-blue-5)
-    );
+  --skeleton-loader_background-a: var(--_color-neutral-2);
+  --skeleton-loader_background-b: var(--_color-neutral-3);
 
-  /* Destructive actions */
-  --color-destructive-action: var(--_color-primary-red-3);
-  --color-destructive-action-hover: var(--_color-primary-red-4);
+  --link_color_default: var(--_color-primary-blue-1);
+  --link_color_hover: var(--_color-primary-blue-3);
 
-  /* Secondary text */
-  --color-secondary-foreground: var(--_color-neutral-5);
+  --link-light_color_default: var(--_color-neutral-1);
+  --link-light_color_hover: var(--_color-neutral-3);
 
-  /* Links */
-  --color-link-foreground: var(--_color-primary-blue-3);
-  --color-link-hover-foreground: var(--_color-primary-yellow-1);
+  /* Component-specific */
+  --page_color_background: var(--_color-neutral-1);
+  --page_color_foreground: var(--_color-neutral-10);
+  --page_color_foreground-secondary: var(--_color-neutral-6);
 
-  /* Containers */
-  --color-container-background: var(--_color-neutral-1);
-  --color-container-border: var(--color-default-border);
+  --page-header_color_background: var(--_color-primary-blue-1);
+  --page-header_color_foreground: var(--_color-neutral-1);
 
-  /* Page flair top bar */
-  --color-page-flair: var(--_color-primary-blue-5);
+  --page-footer_color_background: var(--_color-neutral-9);
+  --page-footer_color_foreground: var(--_color-neutral-4);
+  --page-footer_color_icon: var(--_color-neutral-3);
+  --page-footer_color_background-overlay: rgba(0, 0, 0, 0.2);
+  --page-footer_color_foreground-link: var(--_color-neutral-4);
+  --page-footer_color_foreground-link-hover: var(--_color-neutral-6);
 
-  /* Banners */
-  --color-banner-background: var(--_color-primary-blue-3);
-  --color-banner-highlight: var(--_color-primary-blue-5);
-  --color-banner-shadow: var(--_color-primary-blue-1);
+  --hero_color_background: var(--_color-primary-blue-1);
+  --hero_color_background-secondary: var(--_color-primary-blue-4);
+  --hero_color_foreground: var(--_color-neutral-1);
+  --hero_color_foreground-secondary: var(--_color-neutral-3);
 
-  /* Selections */
-  --color-selection-foreground: var(--_color-neutral-1);
-  --color-selection-background: var(--_color-primary-blue-5);
+  --page-section_color_background-alternate: var(--_color-neutral-2);
+  --page-section_color_background-dark: var(--_color-neutral-8);
+  --page-section_color_foreground-dark: var(--_color-neutral-1);
 
-  /* Navigation links */
-  --color-navigation-links-foreground: var(--_color-neutral-6);
-  --color-navigation-links-background: transparent;
-  --color-navigation-links-border: transparent;
-  --color-navigation-links-hover-foreground: var(--_color-neutral-8);
-  --color-navigation-links-hover-background: var(--_color-neutral-2);
-  --color-navigation-links-hover-border: var(--_color-neutral-6);
-  --color-navigation-links-active-foreground: var(--_color-neutral-1);
-  --color-navigation-links-active-background: var(--_color-neutral-6);
-  --color-navigation-links-active-border: transparent;
+  --button_color_border: var(--_color-neutral-1);
+  --button_color_border-active: var(--_color-primary-blue-4);
 
-  /* Overlay */
-  --color-overlay-background: var(--_color-overlay);
-  --color-overlay-hover-background: var(--_color-overlay);
+  --button-primary_color_foreground: var(--_color-neutral-1);
+  --button-primary_color_background: var(--_color-primary-blue-3);
+  --button-primary_color_background-active: var(--_color-primary-blue-2);
+  --button-primary_color_background-hover: var(--_color-primary-blue-4);
 
-  /* Inputs */
-  --color-input-border: var(--_color-neutral-3);
-  --color-input-foreground: var(--_color-neutral-8);
-  --color-input-background: var(--_color-neutral-1);
+  --button-positive_color_foreground: var(--_color-neutral-1);
+  --button-positive_color_background: var(--_color-primary-green-3);
+  --button-positive_color_background-active: var(--_color-primary-green-2);
+  --button-positive_color_background-hover: var(--_color-primary-green-4);
 
-  --color-input-border-focus: var(--_color-primary-blue-3);
-  --color-input-foreground-focus: var(--_color-neutral-10);
-  --color-input-background-focus: var(--_color-neutral-1);
+  --button-neutral_color_foreground: var(--_color-neutral-1);
+  --button-neutral_color_background: var(--_color-neutral-7);
+  --button-neutral_color_background-active: var(--_color-neutral-8);
+  --button-neutral_color_background-hover: var(--_color-neutral-6);
 
-  /* Errors and warnings */
-  --color-error: var(--_color-primary-red-2);
-  --color-warning: var(--_color-primary-yellow-3);
+  --calendar_color_background: var(--_color-neutral-1);
+  --calendar_color_background-title: var(--_color-primary-blue-3);
+  --calendar_color_foreground-title: var(--_color-neutral-1);
 
-  /* Progress bars */
-  --color-progressbar-active: var(--_color-primary-blue-2);
-  --color-progressbar-track: var(--_color-neutral-3);
+  --navigation-link_color_border: transparent;
+  --navigation-link_color_background: transparent;
+  --navigation-link_color_foreground: var(--_color-neutral-1);
 
-  /* Buttons */
-  --color-button-primary-background: var(--_color-primary-yellow-3)
-    linear-gradient(
-      to bottom,
-      var(--_color-primary-yellow-4),
-      var(--_color-primary-yellow-2)
-    );
-  --color-button-primary-foreground: var(--_color-neutral-10);
+  --navigation-link_color_border-hover: var(--_color-neutral-4);
+  --navigation-link_color_background-hover: transparent;
+  --navigation-link_color_foreground-hover: var(--_color-neutral-3);
 
-  --color-button-secondary-background: var(--_color-neutral-2)
-    linear-gradient(
-      to bottom,
-      var(--_color-neutral-1),
-      var(--_color-neutral-3)
-    );
-  --color-button-secondary-foreground: var(--_color-neutral-7);
+  --navigation-link_color_border-active: var(--_color-primary-blue-3);
+  --navigation-link_color_background-active: var(--_color-primary-blue-3);
+  --navigation-link_color_background-active-alt: var(--_color-primary-blue-2);
+  --navigation-link_color_foreground-active: var(--_color-neutral-1);
 
-  /* Loading spinner */
-  --color-loading-spinner-primary: var(--_color-neutral-1);
-  --color-loading-spinner-secondary: var(--_color-primary-blue-1);
+  --navigation-link_color_foreground-focus: var(--_color-neutral-1);
 
-  /* Skeleton loader colours */
-  --color-loader-skeleton-primary: var(--_color-neutral-2);
-  --color-loader-skeleton-secondary: var(--_color-neutral-3);
+  --banner_color_background: var(--_color-primary-yellow-5);
+  --banner_color_foreground: var(--_color-neutral-10);
 
-  /* Tags */
-  --color-tag-foreground: var(--_color-neutral-4);
-  --color-tag-background: var(--_color-neutral-1);
-  --color-tag-border: var(--color-tag-foreground);
+  --progress-bar_color_background-empty: var(--_color-neutral-3);
+  --progress-bar_color_background-full: var(--_color-primary-blue-2);
 
-  --color-tag-hover-foreground: var(--_color-neutral-1);
-  --color-tag-hover-background: var(--_color-primary-blue-3);
-  --color-tag-hover-border: var(--color-tag-hover-background);
+  --table_color_background: var(--_color-neutral-1);
+  --table_color_background-alt: var(--_color-neutral-2);
+  --table_color_background-title: var(--_color-primary-blue-3);
+  --table_color_foreground-title: var(--_color-neutral-1);
 
-  /* Notifications */
-  --color-notification-background: var(--_color-neutral-1);
-  --color-notification-foreground: var(--_color-neutral-7);
+  --selection_color_background: var(--_color-primary-blue-5);
+  --selection_color_foreground: var(--_color-neutral-1);
 
-  /* Blockquotes */
-  --color-blockquote-border: var(--color-default-border);
-  --color-blockquote-icon: var(--color-blockquote-border);
-  --color-blockquote-foreground: inherit;
+  --tag_color_background: var(--_color-neutral-7);
+  --tag_color_background-hover: var(--_color-neutral-9);
+  --tag_color_foreground: var(--_color-neutral-1);
+  --tag_color_foreground-hover: var(--_color-neutral-1);
 
-  /* Tables */
-  --color-table-row-background: var(--_color-neutral-1);
-  --color-table-row-background-alt: var(--_color-neutral-2);
+  --load-spinner_color_primary: var(--_color-neutral-1);
+  --load-spinner_color_secondary: var(--_color-neutral-9);
 
-  /* Dashboard */
-  --color-dashboard-side-background: var(--_color-primary-blue-1);
-  --color-dashboard-side-foreground: var(--_color-neutral-1);
-  --color-dashboard-side-hover-background: var(--_color-primary-blue-4);
-  --color-dashboard-side-hover-foreground: var(--_color-neutral-1);
-  --color-dashboard-side-selected-background: var(--color-container-background);
-  --color-dashboard-side-selected-foreground: var(--color-default-foreground);
+  --gallery-thumbnail-overlay_color_background: var(--_color-overlay);
+  --gallery-thumbnail-overlay_color_foreground: var(--_color-neutral-10);
 
-  /* Specific */
-  --color-slide-indicator: var(--_color-primary-blue-3);
-  --color-slide-indicator-hover: var(--_color-primary-blue-5);
-}
-
-/* Dark color mode palette */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --_color-neutral-1: #1d232f;
-    --_color-neutral-2: #2e374a;
-    --_color-neutral-3: #3e4b65;
-    --_color-neutral-4: #4f5f80;
-    --_color-neutral-5: #5f739a;
-    --_color-neutral-6: #798aac;
-    --_color-neutral-7: #94a1bd;
-    --_color-neutral-8: #aeb9cd;
-    --_color-neutral-9: #c9d0de;
-    --_color-neutral-10: #e4e8ee;
-    --_color-shadow: rgba(0, 0, 0, 0.5);
-    --_color-overlay: rgba(29, 35, 47, 0.8);
-
-    --color-default-gradient: var(--_color-primary-blue-2)
-    linear-gradient(
-      to bottom,
-      var(--_color-primary-blue-1),
-      var(--_color-primary-blue-3)
-    );
-    --color-destructive-action: var(--_color-primary-red-1);
-    --color-destructive-action-hover: var(--_color-primary-red-2);
-    --color-light-foreground: var(--_color-neutral-10);
-    --color-link-foreground: var(--_color-primary-yellow-1);
-    --color-link-hover-foreground: var(--_color-primary-yellow-3);
-    --color-button-primary-background: var(--_color-primary-yellow-2)
-      linear-gradient(
-        to bottom,
-        var(--_color-primary-yellow-3),
-        var(--_color-primary-yellow-1)
-      );
-    --color-button-primary-foreground: var(--_color-neutral-1);
-    --color-button-secondary-background: var(--_color-neutral-2)
-      linear-gradient(
-        to bottom,
-        var(--_color-neutral-3),
-        var(--_color-neutral-2)
-      );
-    --color-button-secondary-foreground: var(--_color-neutral-7);
-    --color-banner-background: var(--_color-primary-blue-1);
-    --color-banner-highlight: var(--_color-neutral-5);
-    --color-banner-shadow: var(--_color-neutral-1);
-    --color-loading-spinner-primary: var(--color-default-background);
-    --color-loading-spinner-secondary: var(--_color-neutral-7);
-    --color-progressbar-active: var(--_color-primary-blue-3);
-    --color-tag-hover-background: var(--color-link-foreground);
-    --color-input-foreground: var(--color-default-foreground);
-    --color-input-background: var(--_color-neutral-2);
-    --color-input-foreground-focus: var(--color-default-foreground);
-    --color-input-background-focus: var(--_color-neutral-3);
-    --color-dashboard-side-background: var(--_color-neutral-3);
-    --color-dashboard-side-foreground: var(--_color-neutral-8);
-    --color-dashboard-side-hover-background: var(--_color-neutral-2);
-    --color-dashboard-side-hover-foreground: var(--_color-neutral-9);
-    --color-dashboard-side-selected-foreground: var(--_color-neutral-10);
-  }
+  --fancy-heading-1_color_a: var(--_color-primary-blue-5);
+  --fancy-heading-1_color_b: var(--_color-primary-blue-1);
 }


### PR DESCRIPTION
This change set implements v3 of the colour palette. The idea behind v3 was to make it easier to understand what components the colours are intended for:

v2 and below grouped the CSS properties in the format `--<property type>-<component>-<usage>` i.e. `--color-default-foreground` which meant that the style sheet was hard to reason with as all the variables in it were named `--color-*`.

v3 makes it easier to see how to use the variables, by naming variables in the format `--<component>-<property type>-<usage>` i.e. `--page_color_foreground`. This will allow consumers to easily recognise which variables to use for what areas.

v3 drops the dark mode theme for the time being. It does not appear visually consistent so I have removed it while continuing to work on it.