### PR TITLE
Prepare release 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jbrowneuk/style-bundle",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "sass": "^1.83.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Global style files for Jason B’s Portfolio",
   "main": "styles.css",
   "files": [


### PR DESCRIPTION
This version fixes an oversight with responsive elements in blog posts where the responsive style would not be applied to anything other than images.