### PR TITLE
Revert changes to enable sticky footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jbrowneuk/style-bundle",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "devDependencies": {
         "sass": "^1.83.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbrowneuk/style-bundle",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Global style files for Jason B’s Portfolio",
   "main": "styles.css",
   "files": [

--- a/src/core/_page-base.scss
+++ b/src/core/_page-base.scss
@@ -17,18 +17,6 @@ body {
 }
 
 html {
-  height: 100%;
   max-height: 100vh;
   overflow: auto;
 }
-
-body {
-  height: 100%;
-  display:flex;
-  flex-direction:column;
-
-  & > main {
-    flex: 1 0 auto;
-  }
-}
-


### PR DESCRIPTION
This reverts the changes introduced to make the footer stick to the bottom of the viewport. It worked inconsistently between mobile and desktop browsers so further work is needed.

This reverts commit a807414abd19a4a8f0718aa8d6a149c260a4f04d.